### PR TITLE
Fix #34

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ Tor/Obj
 *.sdf
 
 Releases/
+/.vs/slnx.sqlite

--- a/Popcorn/Services/Genres/GenreService.cs
+++ b/Popcorn/Services/Genres/GenreService.cs
@@ -91,13 +91,8 @@ namespace Popcorn.Services.Genres
                     },
                     new GenreJson
                     {
-                        EnglishName = "Science Fiction",
-                        Name = language == "fr" ? "Science-Fiction" : "Science Fiction"
-                    },
-                    new GenreJson
-                    {
-                        EnglishName = "TV Movie",
-                        Name = language == "fr" ? "Téléfilm" : "TV Movie"
+                        EnglishName = "Sci-Fi",
+                        Name = language == "fr" ? "Sci-Fi" : "Sci-Fi"
                     },
                     new GenreJson
                     {


### PR DESCRIPTION
TV Movie genre was unnecessary as it yielded no results. Science Fiction was renamed to Sci-Fi to match the tag.