### PR TITLE
Prevent download subtitle file if it has been downloaded before

### DIFF
--- a/Popcorn.OSDB/AnonymousClient.cs
+++ b/Popcorn.OSDB/AnonymousClient.cs
@@ -97,6 +97,13 @@ namespace Popcorn.OSDB
 
             var destinationfile = Path.Combine(path,
                 (string.IsNullOrEmpty(newSubtitleName)) ? subtitle.SubtitleFileName : newSubtitleName);
+
+            if (File.Exists(destinationfile))
+            {
+                //if file has been downloaded before - there is no need to download it again
+                return destinationfile;
+            }
+
             var tempZipName = Path.GetTempFileName();
             try
             {


### PR DESCRIPTION
Small improvement: 
1. Prevents download subtitle file if it has been downloaded before.
2. If subtitle has been selected before, VclPlayer holds subtitle file opened event when another subtitle has been selected. When application tries to unzip downloaded subtitle file, it faces with issue when destination 'file is used by another process'. So downloading method fails with an execption, and setting subtitle is not completed. This improvement also fixes this issue.